### PR TITLE
Add AutoDarts settings UI and installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,24 +10,28 @@ RGB matrix.  The project contains two main entry points:
 
 ## Development
 
+Set up a virtual environment and install the dependencies, including those required for running tests:
+
 ```bash
 python -m venv .venv
 source .venv/bin/activate
 pip install -r requirements.txt
 ```
 
+The project relies on the [hzeller/rpi-rgb-led-matrix](https://github.com/hzeller/rpi-rgb-led-matrix)
+library for driving the display.  A convenience script is provided to
+install or update this dependency along with the Python requirements:
+
+```bash
+./install.sh
+```
+
 ## Running the round relay
 
-The websocket relay requires a number of environment variables for authenticating
-against AutoDarts:
+Credentials for talking to the AutoDarts API are read from
+`settings.json`.  They can be edited via the web interface at `/darts`.
 
-- `AUTODARTS_USERNAME`
-- `AUTODARTS_PASSWORD`
-- `AUTODARTS_CLIENT_ID`
-- `AUTODARTS_CLIENT_SECRET`
-- `AUTODARTS_BOARD_ID`
-
-Start the service with:
+Start the websocket relay service with:
 
 ```bash
 python simple_round_ws.py

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -e
+
+# Install required packages
+sudo apt-get update
+sudo apt-get install -y git python3-dev python3-pip python3-venv python3-pillow
+
+# Clone or update rpi-rgb-led-matrix
+if [ ! -d rpi-rgb-led-matrix ]; then
+  git clone https://github.com/hzeller/rpi-rgb-led-matrix.git
+else
+  (cd rpi-rgb-led-matrix && git pull)
+fi
+
+# Build and install Python bindings
+(cd rpi-rgb-led-matrix/bindings/python && make build-python && sudo make install-python)
+
+# Install Python dependencies
+pip install -r requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ pycaw; platform_system == "Windows"
 cryptography==42.0.5
 dotenv==0.9.9
 python-dotenv
+pytest>=7

--- a/settings.json
+++ b/settings.json
@@ -4,5 +4,10 @@
     "chain_length": 3,
     "hardware_mapping": "regular",
     "gpio_slowdown": 4,
-    "pwm_lsb_nanoseconds": 80
+    "pwm_lsb_nanoseconds": 80,
+    "autodarts_username": "",
+    "autodarts_password": "",
+    "autodarts_client_id": "",
+    "autodarts_client_secret": "",
+    "autodarts_board_id": ""
 }

--- a/simple_round_ws.py
+++ b/simple_round_ws.py
@@ -13,6 +13,7 @@ from flask_socketio import SocketIO
 from autodarts_keycloak_client import AutodartsKeycloakClient
 
 AUTODARTS_WEBSOCKET_URL = "wss://api.autodarts.io/ms/v0/subscribe"
+SETTINGS_FILE = "/home/pi/rgbserver/settings.json"
 
 app = Flask(__name__)
 socketio = SocketIO(app, async_mode="threading")
@@ -29,18 +30,49 @@ def get_env(name: str) -> str:
     return value
 
 
+def load_settings() -> dict:
+    """Load settings from ``SETTINGS_FILE``."""
+
+    if not os.path.exists(SETTINGS_FILE):
+        return {}
+    with open(SETTINGS_FILE, "r") as fh:
+        return json.load(fh)
+
+
+def get_setting(name: str) -> str:
+    """Return AutoDarts credential ``name`` from env or settings file."""
+
+    env = os.getenv(name)
+    if env:
+        return env
+
+    mapping = {
+        "AUTODARTS_USERNAME": "autodarts_username",
+        "AUTODARTS_PASSWORD": "autodarts_password",
+        "AUTODARTS_CLIENT_ID": "autodarts_client_id",
+        "AUTODARTS_CLIENT_SECRET": "autodarts_client_secret",
+        "AUTODARTS_BOARD_ID": "autodarts_board_id",
+    }
+    settings = load_settings()
+    key = mapping.get(name)
+    value = settings.get(key) if settings else None
+    if not value:
+        raise RuntimeError(f"Missing setting: {name}")
+    return value
+
+
 def run_autodarts_ws() -> None:
     """Listen to the AutoDarts websocket and emit round events via SocketIO."""
 
     os.environ["SSL_CERT_FILE"] = certifi.where()
     kc = AutodartsKeycloakClient(
-        username=get_env("AUTODARTS_USERNAME"),
-        password=get_env("AUTODARTS_PASSWORD"),
-        client_id=get_env("AUTODARTS_CLIENT_ID"),
-        client_secret=get_env("AUTODARTS_CLIENT_SECRET"),
+        username=get_setting("AUTODARTS_USERNAME"),
+        password=get_setting("AUTODARTS_PASSWORD"),
+        client_id=get_setting("AUTODARTS_CLIENT_ID"),
+        client_secret=get_setting("AUTODARTS_CLIENT_SECRET"),
     )
     kc.start()
-    board_id = get_env("AUTODARTS_BOARD_ID")
+    board_id = get_setting("AUTODARTS_BOARD_ID")
 
     def on_open(ws):
         subscribe = {

--- a/templates/base.html
+++ b/templates/base.html
@@ -29,10 +29,11 @@
     <h1 class="text-center">LED Matrix Controller</h1>
     <p class="text-center">
         <a href="/">Home</a> | 
-        <a href="/settings">Einstellungen</a> | 
-        <a href="/gif">GIF Steuerung</a> | 
+        <a href="/settings">Einstellungen</a> |
+        <a href="/gif">GIF Steuerung</a> |
         <a href="/playlist">Playlist</a> |
-		<a href="/dart">Darts</a>
+                <a href="/dart">Darts</a> |
+        <a href="/darts">AutoDarts Settings</a>
     </p>
     {% block content %}{% endblock %}
 </div>

--- a/templates/darts.html
+++ b/templates/darts.html
@@ -1,0 +1,30 @@
+{% extends "base.html" %}
+{% block title %}AutoDarts Einstellungen{% endblock %}
+{% block content %}
+<div class="card">
+    <h3>AutoDarts Einstellungen</h3>
+    <form method="POST">
+        <div class="form-group">
+            <label>Benutzername</label>
+            <input name="autodarts_username" class="form-control" value="{{ s.autodarts_username }}">
+        </div>
+        <div class="form-group">
+            <label>Passwort</label>
+            <input name="autodarts_password" type="password" class="form-control" value="{{ s.autodarts_password }}">
+        </div>
+        <div class="form-group">
+            <label>Client ID</label>
+            <input name="autodarts_client_id" class="form-control" value="{{ s.autodarts_client_id }}">
+        </div>
+        <div class="form-group">
+            <label>Client Secret</label>
+            <input name="autodarts_client_secret" class="form-control" value="{{ s.autodarts_client_secret }}">
+        </div>
+        <div class="form-group">
+            <label>Board ID</label>
+            <input name="autodarts_board_id" class="form-control" value="{{ s.autodarts_board_id }}">
+        </div>
+        <button type="submit" class="btn btn-success">Speichern</button>
+    </form>
+</div>
+{% endblock %}

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,0 +1,26 @@
+import json
+import pathlib
+import sys
+
+import pytest
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+import simple_round_ws
+
+
+def test_get_setting_reads_file(monkeypatch, tmp_path):
+    data = {"autodarts_username": "foo"}
+    cfg = tmp_path / "settings.json"
+    cfg.write_text(json.dumps(data))
+    monkeypatch.delenv("AUTODARTS_USERNAME", raising=False)
+    monkeypatch.setattr(simple_round_ws, "SETTINGS_FILE", str(cfg))
+    assert simple_round_ws.get_setting("AUTODARTS_USERNAME") == "foo"
+
+
+def test_get_setting_missing(monkeypatch, tmp_path):
+    cfg = tmp_path / "settings.json"
+    cfg.write_text("{}")
+    monkeypatch.delenv("AUTODARTS_USERNAME", raising=False)
+    monkeypatch.setattr(simple_round_ws, "SETTINGS_FILE", str(cfg))
+    with pytest.raises(RuntimeError):
+        simple_round_ws.get_setting("AUTODARTS_USERNAME")

--- a/webserver.py
+++ b/webserver.py
@@ -285,6 +285,23 @@ def config():
 
     return render_template("settings.html", s=settings)
 
+
+@app.route("/darts", methods=["GET", "POST"])
+def darts_settings():
+    settings = load_settings()
+    if request.method == "POST":
+        settings.update({
+            "autodarts_username": request.form.get("autodarts_username", ""),
+            "autodarts_password": request.form.get("autodarts_password", ""),
+            "autodarts_client_id": request.form.get("autodarts_client_id", ""),
+            "autodarts_client_secret": request.form.get("autodarts_client_secret", ""),
+            "autodarts_board_id": request.form.get("autodarts_board_id", ""),
+        })
+        save_settings(settings)
+        return redirect("/darts")
+
+    return render_template("darts.html", s=settings)
+
 @app.route("/gif")
 def gif_list():
     gif_files = [f for f in os.listdir(GIF_FOLDER) if f.lower().endswith(".gif")]


### PR DESCRIPTION
## Summary
- expose AutoDarts credentials in `settings.json` with a `/darts` web UI for editing
- load credentials from the settings file in the websocket relay and cover with tests
- include installer script for `rpi-rgb-led-matrix` and document installation

## Testing
- `pip install -r requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_689a5a0ac2388332886169ad84c4ea7c